### PR TITLE
Fix Letta config to use right variable for baseURL

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -403,7 +403,7 @@ export default class LettaPlugin extends Plugin {
 
 			// Initialize with token and base URL from settings
 			const config: any = {
-				baseURL: this.settings.lettaBaseUrl,
+				baseUrl: this.settings.lettaBaseUrl,
 			};
 
 			// Only add token if API key is provided (for self-hosted without auth)


### PR DESCRIPTION
This pull request includes a minor fix to the configuration object initialization in the `LettaPlugin` class. The change corrects a property name to ensure the base URL is set properly.

* Updated the configuration object in the `LettaPlugin` class to use `baseUrl` instead of `baseURL`, aligning with expected property naming.